### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ## Installation
 The easiest way to "install" LÖVEBrew is from the [releases page](https://github.com/TurtleP/lovebrew/releases). Download the respective platform's release and put it in the following directory for your operating system:
 
-- Windows: `%appdata%/.lovebrew/bin`
-  - Create this directory and add it to your PATH!
-- Linux: `/usr/bin`
-- macOS: TBD
+- Windows: `%APPDATA%/lovebrew/bin`
+  - Create this directory and add it to your PATH
+- macOS/Linux: `~/bin` or `/usr/local/bin`
+  - Should be automatically added to PATH after a reboot
 
 ## Building a Project
-LÖVEBrew will look for the LÖVE Potion ELF binaries by default in the OS configuration directory. They must be named accordingly as `3DS.elf` or `Switch.elf`, depending on the build targets.
+LÖVEBrew will look for the LÖVE Potion ELF binaries by default in the OS configuration directory. They must be named accordingly as `3ds.elf` or `switch.elf`, depending on the build targets.
 However, you *can* override this setting inside the config file and it will search relative to the project's root. The config directory is at the following locations:
 
-- Windows: `%appdata%/.lovebrew`
-- Linux and macOS: `~/.config/.lovebrew`
+- Windows: `%APPDATA%/lovebrew`
+- macOS/Linux: `~/.config/lovebrew`
 
 ## Options
 ```

--- a/lovebrew.nimble
+++ b/lovebrew.nimble
@@ -11,7 +11,7 @@ binDir = "dist"
 
 # Dependencies
 
-requires "nim >= 1.4.6"
+requires "nim >= 1.4.0"
 requires "zippy"
 requires "parsetoml"
 requires "cligen"

--- a/src/assets/lovebrew.toml
+++ b/src/assets/lovebrew.toml
@@ -1,9 +1,9 @@
 ## --- Metadata Options --- ##
 
-# [string] @name        : Name of the game, default: name of the directory.
+# [string] @name        : Name of the game. If set to false, name of the directory.
 # [string] @author      : Author of the game.
 # [string] @description : Description of the game.
-# [string] @version     : Version of the game in {major}.{minor}.{revision} format.
+# [string] @version     : Version of the game, preferrably in {major}.{minor}.{revision} format.
 [metadata]
 name = "SuperGame"
 author = "SuperAuthor"
@@ -14,17 +14,20 @@ version = "0.1.0"
 
 # [bool]   @clean         : Clean the build artifacts and directory before a new build.
 #                           This helps reduce chances of cluttering the built data.
-#                           Default: false.
+#                           Default: false
 #
-# [array]  @targts        : Target console(s) to build for. Default: ["3ds", "switch"].
+# [array]  @targts        : Target console(s) to build for.
+#                           Default: ["3ds", "switch"]
 #
 # [string] @source        : Game source directory; relative to the config
-#                           file. Default: "game".
+#                           file.
+#                           Default: "game"
 #
 # [string] @icon          : Icon name. Do not provide the extension.
 #                           lovebrew will automatically provide this.
 #                           It can include a prepended path. This is relative
-#                           to the config file. Default: "icon".
+#                           to the config file.
+$                           Default: "icon"
 #
 # [string] @binSearchPath : Location to search for the elf binaries.
 #                           Default: ""
@@ -37,24 +40,24 @@ binSearchPath = ""
 
 ## --- Output Options --- ##
 
-# [string] @build   : Output directory for compilation; relative to the config
-#                     file. When false, it will use current directory.
-#                     Default: "build".
+# [string] @build      : Output directory for compilation; relative to the config
+#                        file. When false, it will use current directory.
+#                        Default: "build"
 #
-# [bool]   @rawData : Whether or not to properly build a 3DS project binary.
-#                     This will not build a 3DS application. See @build.targets.
-#                     When false, outputs as a 3dsx; when true, output only
-#                     as the "raw" game folder used for testing purposes.
-#                     Default: false.
+# [bool]   @rawData    : Whether or not to properly build a 3DS project binary.
+#                        This will not build a 3DS application. See @build.targets.
+#                        When false, outputs as a 3dsx; when true, output only
+#                        as the "raw" game folder used for testing purposes.
+#                        Default: false
 #
-# [string] @romFS   : The directory within the build directory which gets
-#                     zipped and appended to the resulting binary. Default: "game".
-#                     NOTE: if "rawData" is true, this does not get zipped and can
-#                     be used for quick testing. However, the directory must be named
-#                     as the default, "game".
+# [string] @outputName : The name used for the binaries lovebrew outputs.
+#                        Default: "game"
+#                        NOTE: If "rawData" is true, the source directory will not get
+#                        zipped and can be used for quick testing. However, outputName
+#                        must be set to "game".
 [output]
 build = "build"
 rawData = false
-romFS = "game"
+outputName = "game"
 
 # VERSION 0.5.0 #

--- a/src/assets/lovebrew.toml
+++ b/src/assets/lovebrew.toml
@@ -27,7 +27,7 @@ version = "0.1.0"
 #                           lovebrew will automatically provide this.
 #                           It can include a prepended path. This is relative
 #                           to the config file.
-$                           Default: "icon"
+#                           Default: "icon"
 #
 # [string] @binSearchPath : Location to search for the elf binaries.
 #                           Default: ""

--- a/src/configure.nim
+++ b/src/configure.nim
@@ -24,7 +24,7 @@ type
         # Output
         build*: string
         rawData*: bool
-        romFS*: string
+        outputName*: string
 
 var config*: Config
 
@@ -67,7 +67,7 @@ proc loadBuild(conf: var Config, toml: TomlValueRef) =
 proc loadOutput(conf: var Config, toml: TomlValueRef) =
     conf.build = toml["build"].getStr()
     conf.rawData = toml["rawData"].getBool()
-    conf.romFS = toml["romFS"].getStr()
+    conf.outputName = toml["outputName"].getStr()
 
 proc load*(): bool =
     try:

--- a/src/configure.nim
+++ b/src/configure.nim
@@ -28,8 +28,8 @@ type
 
 var config*: Config
 
-let ConfigFilePath* = os.normalizedPath(getCurrentDir() & "/lovebrew.toml")
-let ConfigDirectory* = os.normalizedPath(getConfigDir() & "/lovebrew")
+let ConfigFilePath* = os.normalizedPath(os.getCurrentDir() & "/lovebrew.toml")
+let ConfigDirectory* = os.normalizedPath(os.getConfigDir() & "/lovebrew")
 
 var TargetsTable: Table[string, Target]
 

--- a/src/configure.nim
+++ b/src/configure.nim
@@ -29,7 +29,7 @@ type
 var config*: Config
 
 let ConfigFilePath* = os.normalizedPath(getCurrentDir() & "/lovebrew.toml")
-let ConfigDirectory* = os.normalizedPath(getConfigDir() & "/.lovebrew")
+let ConfigDirectory* = os.normalizedPath(getConfigDir() & "/lovebrew")
 
 var TargetsTable: Table[string, Target]
 

--- a/src/lovebrew.nim
+++ b/src/lovebrew.nim
@@ -55,7 +55,7 @@ proc build() =
     os.createDir(config.build)
 
     for target in config.targets:
-        TargetClasses[target].publish(config.source)
+        TargetClasses[target].publish()
 
 proc clean() =
     ## Clean the set output directory

--- a/src/types/console.nim
+++ b/src/types/console.nim
@@ -16,7 +16,7 @@ iface *Console:
     proc getConsoleName(): string
     proc getElfBinaryName(): string
     proc getIconExtension(): string
-    proc publish(source: string)
+    proc publish()
 
 proc getElfBinaryPath*(self: Console): string =
     ## Return the full path to the ELF binary
@@ -26,7 +26,7 @@ proc getElfBinaryPath*(self: Console): string =
 proc getOutputBinaryName*(self: Console): string =
     ## Return the filename with extension (.nro/3dsx)
 
-    return fmt("{config.name}.{self.getBinaryExtension()}")
+    return fmt("{config.romfs}.{self.getBinaryExtension()}")
 
 proc getOutputBinaryPath*(self: Console): string =
     ## Return the full path where the binary is output to

--- a/src/types/console.nim
+++ b/src/types/console.nim
@@ -26,7 +26,7 @@ proc getElfBinaryPath*(self: Console): string =
 proc getOutputBinaryName*(self: Console): string =
     ## Return the filename with extension (.nro/3dsx)
 
-    return fmt("{config.romfs}.{self.getBinaryExtension()}")
+    return fmt("{config.outputName}.{self.getBinaryExtension()}")
 
 proc getOutputBinaryPath*(self: Console): string =
     ## Return the full path where the binary is output to
@@ -61,12 +61,12 @@ proc getIcon*(self: Console): string =
 
     return filename
 
-proc packGameDirectory*(self: Console, romFS: string) =
-    let content = fmt("{config.romFS}.love")
+proc packGameDirectory*(self: Console, outputName: string) =
+    let content = fmt("{config.outputName}.love")
     let tempBinaryPath = self.getTempBinaryPath()
 
     try:
-        ziparchives.createZipArchive(romFS, content)
+        ziparchives.createZipArchive(outputName, content)
 
         let binaryData = readFile(tempBinaryPath)
         writeFile(self.getOutputBinaryPath(), binaryData & readFile(content))
@@ -78,7 +78,7 @@ proc packGameDirectory*(self: Console, romFS: string) =
 proc getRomFSDirectory*(): string =
     ## Return the relative "RomFS" directory
 
-    return fmt("{config.build}/{config.romFS}")
+    return fmt("{config.build}/{config.outputName}")
 
 proc runCommand*(command: string) =
     ## Runs a specified command

--- a/src/types/ctr.nim
+++ b/src/types/ctr.nim
@@ -22,7 +22,7 @@ type
 
 proc getBinaryExtension*(self: Ctr): string = "3dsx"
 proc getConsoleName*(self: Ctr): string = "Nintendo 3DS"
-proc getElfBinaryName*(self: Ctr): string = "3DS.elf"
+proc getElfBinaryName*(self: Ctr): string = "3ds.elf"
 proc getIconExtension*(self: Ctr): string = "png"
 
 proc convertFiles(self: Ctr, source: string): bool =

--- a/src/types/ctr.nim
+++ b/src/types/ctr.nim
@@ -26,7 +26,7 @@ proc getElfBinaryName*(self: Ctr): string = "3DS.elf"
 proc getIconExtension*(self: Ctr): string = "png"
 
 proc convertFiles(self: Ctr, source: string): bool =
-    let romFS = console.getRomFSDirectory()
+    let outputName = console.getRomFSDirectory()
 
     for path in os.walkDirRec(source, relative = true):
         if os.isHidden(path):
@@ -35,7 +35,7 @@ proc convertFiles(self: Ctr, source: string): bool =
         let (dir, name, extension) = os.splitFile(path)
 
         let relativePath = fmt("{source}/{path}")
-        let destination = fmt("{romFS}/{dir}")
+        let destination = fmt("{outputName}/{dir}")
 
         try:
             os.createDir(destination)
@@ -81,4 +81,4 @@ proc publish*(self: Ctr) =
         echo(e.msg)
         return
 
-    self.packGameDirectory(fmt("{config.romFS}/"))
+    self.packGameDirectory(fmt("{config.outputName}/"))

--- a/src/types/ctr.nim
+++ b/src/types/ctr.nim
@@ -55,17 +55,16 @@ proc convertFiles(self: Ctr, source: string): bool =
 
     return true
 
-proc publish*(self: Ctr, source: string) =
-    if not self.convertFiles(source):
+proc publish*(self: Ctr) =
+    if not self.convertFiles(config.source):
         return
 
     let elfBinaryPath = self.getElfBinaryPath()
 
     if not os.fileExists(elfBinaryPath) and not config.rawData:
-        echo(strings.ElfBinaryNotFound.format(
+        raise newException(Exception, strings.ElfBinaryNotFound.format(
                 config.name, self.getConsoleName(), self.getElfBinaryName(),
                 config.binSearchPath))
-        return
 
     let properDescription = fmt("{config.description} • {config.version}")
     let tempBinaryPath = self.getTempMetadataBinaryPath()

--- a/src/types/hac.nim
+++ b/src/types/hac.nim
@@ -10,8 +10,8 @@ import ../configure
 import ../strings
 
 const ZipCommand = """cd "$1"; zip -r -9 $2 ."""
-const NacpCommand = """cd "$1"; nacptool --create "$2" "$3" "$4" "$5.nacp""""
-const BinaryCommand = """cd "$1"; elf2nro "$2" "$3.nro" --icon="$4" --nacp="$3.nacp" --romfsdir="romfs""""
+const NacpCommand = """cd "$1"; nacptool --create "$2" "$3" "$4" "game.nacp""""
+const BinaryCommand = """cd "$1"; elf2nro "$2" "$3.nro" --icon="$4" --nacp="game.nacp" --romfsdir="romfs""""
 
 type
     Hac* = ref object of ConsoleBase
@@ -36,8 +36,8 @@ proc publish*(self: Hac) =
                 config.binSearchPath))
 
     let build = config.build
-    let currentDir = getCurrentDir()
-    let lovePath = fmt("{build}/{config.outputName}.love")
+    let currentDir = os.getCurrentDir()
+    let lovePath = fmt("{build}/game.love")
 
     ### Create `SuperGame`.love in the build directory
     console.runCommand(ZipCommand.format(config.source, fmt("{currentDir}/{lovePath}")))
@@ -45,7 +45,7 @@ proc publish*(self: Hac) =
     let outputName = config.outputName
 
     ### Create `SuperGame`.nacp in the build directory
-    console.runCommand(NacpCommand.format(build, name, config.author, config.version, outputName))
+    console.runCommand(NacpCommand.format(build, name, config.author, config.version))
 
     ### Create `SuperGame`.nro in the build directory
     console.runCommand(BinaryCommand.format(build, elfBinaryPath, outputName, fmt("{currentDir}/{self.getIcon()}")))
@@ -54,3 +54,8 @@ proc publish*(self: Hac) =
 
     ### Finalize `SuperGame`.nro in the build directory
     writeFile(outputBinaryPath, readFile(outputBinaryPath) & readFile(lovePath))
+
+    ### Post-build cleanup
+    os.removeDir(fmt("{build}/romfs"))
+    os.removeFile(lovePath)
+    os.removeFile(fmt("{build}/game.nacp"))

--- a/src/types/hac.nim
+++ b/src/types/hac.nim
@@ -23,7 +23,6 @@ proc getIconExtension*(self: Hac): string = "jpg"
 
 proc publish*(self: Hac) =
     ### Write the needed shaders to their proper directory
-
     os.createDir(fmt("{config.build}/romfs/shaders"))
     for key, value in HacShaders.items():
         writeFile(fmt("{config.build}/romfs/shaders/{key}.dksh"), value)
@@ -38,18 +37,18 @@ proc publish*(self: Hac) =
 
     let build = config.build
     let currentDir = getCurrentDir()
-    let lovePath = fmt("{build}/{config.romFS}.love")
+    let lovePath = fmt("{build}/{config.outputName}.love")
 
     ### Create `SuperGame`.love in the build directory
     console.runCommand(ZipCommand.format(config.source, fmt("{currentDir}/{lovePath}")))
 
-    let romFS = config.romFS
+    let outputName = config.outputName
 
     ### Create `SuperGame`.nacp in the build directory
-    console.runCommand(NacpCommand.format(build, name, config.author, config.version, romFS))
+    console.runCommand(NacpCommand.format(build, name, config.author, config.version, outputName))
 
     ### Create `SuperGame`.nro in the build directory
-    console.runCommand(BinaryCommand.format(build, elfBinaryPath, romFS, fmt("{currentDir}/{self.getIcon()}")))
+    console.runCommand(BinaryCommand.format(build, elfBinaryPath, outputName, fmt("{currentDir}/{self.getIcon()}")))
 
     let outputBinaryPath = self.getOutputBinaryPath()
 

--- a/src/types/hac.nim
+++ b/src/types/hac.nim
@@ -18,7 +18,7 @@ type
 
 proc getBinaryExtension*(self: Hac): string = "nro"
 proc getConsoleName*(self: Hac): string = "Nintendo Switch"
-proc getElfBinaryName*(self: Hac): string = "Switch.elf"
+proc getElfBinaryName*(self: Hac): string = "switch.elf"
 proc getIconExtension*(self: Hac): string = "jpg"
 
 proc publish*(self: Hac) =


### PR DESCRIPTION
Miscellaneous fixes that help give the lovebrew rewrite parity with the Python version and enhance some other features.

Currently, only the HAC script has been changed since I need to do more research with the CTR script and the 3DS version of LovePotion.

Changelog:
* Fixed several issues with and optimized the HAC script, now compilation exclusively occurs in the build directory
* The "romFS" setting has been fittingly renamed to "outputName," and its description has been changed too
* Directory for lovebrew has been changed from `.lovebrew` to `lovebrew`
* Lovebrew ELFs are now lowercase (i.e. `3ds.elf`, `switch.elf`)
* Updated README
* Added post-build cleanup to HAC
* Minimum Nimble version is now 1.4.0