### PR TITLE
Wrap more command-line args in quotations

### DIFF
--- a/src/enums/command.nim
+++ b/src/enums/command.nim
@@ -6,14 +6,14 @@ import ../data/strings
 
 type
     Command* = enum
-        Tex3ds = "tex3ds \"$1\" -o \"$2\""
-        Mkbcfnt = "mkbcfnt \"$1\" -o \"$2\""
+        Tex3ds = """tex3ds "$1" -o "$2""""
+        Mkbcfnt = """mkbcfnt "$1" -o "$2""""
 
-        CtrUpdate = "hbupdater ctr --filepath \"$1\" --title \"$2\" --author \"$3\" --description \"$4\" --iconPath \"$5\" --output \"$6\""
-        CtrUpdateNoIcon = "hbupdater ctr --filepath \"$1\" --title \"$2\" --author \"$3\" --description \"$4\" --output \"$5\""
+        CtrUpdate = """hbupdater ctr --filepath "$1" --title "$2" --author "$3" --description "$4" --iconPath "$5" --output "$6""""
+        CtrUpdateNoIcon = """hbupdater ctr --filepath "$1" --title "$2" --author "$3" --description "$4" --output "$5""""
 
-        HacUpdate = "hbupdater hac --filepath \"$1\" --title \"$2\" --author \"$3\" --iconPath \"$4\" --output \"$5\""
-        HacUpdateNoIcon = "hbupdater hac --filepath \"$1\" --title \"$2\" --author \"$3\" --output \"$4\""
+        HacUpdate = """hbupdater hac --filepath "$1" --title "$2" --author "$3" --iconPath "$4" --output "$5""""
+        HacUpdateNoIcon = """hbupdater hac --filepath "$1" --title "$2" --author "$3" --output "$4""""
 
 proc run*(command: string, args: varargs[string, `$`]): bool =
     let commandString = command.format(args).replace("\\", "/")

--- a/src/enums/command.nim
+++ b/src/enums/command.nim
@@ -6,14 +6,14 @@ import ../data/strings
 
 type
     Command* = enum
-        Tex3ds = "tex3ds $1 -o $2"
-        Mkbcfnt = "mkbcfnt $1 -o $2"
+        Tex3ds = "tex3ds \"$1\" -o \"$2\""
+        Mkbcfnt = "mkbcfnt \"$1\" -o \"$2\""
 
-        CtrUpdate = "hbupdater ctr --filepath $1 --title \"$2\" --author \"$3\" --description \"$4\" --iconPath $5 --output $6"
-        CtrUpdateNoIcon = "hbupdater ctr --filepath $1 --title \"$2\" --author \"$3\" --description \"$4\" --output $5"
+        CtrUpdate = "hbupdater ctr --filepath \"$1\" --title \"$2\" --author \"$3\" --description \"$4\" --iconPath \"$5\" --output \"$6\""
+        CtrUpdateNoIcon = "hbupdater ctr --filepath \"$1\" --title \"$2\" --author \"$3\" --description \"$4\" --output \"$5\""
 
-        HacUpdate = "hbupdater hac --filepath $1 --title \"$2\" --author \"$3\" --iconPath $4 --output $5"
-        HacUpdateNoIcon = "hbupdater hac --filepath $1 --title \"$2\" --author \"$3\" --output $4"
+        HacUpdate = "hbupdater hac --filepath \"$1\" --title \"$2\" --author \"$3\" --iconPath \"$4\" --output \"$5\""
+        HacUpdateNoIcon = "hbupdater hac --filepath \"$1\" --title \"$2\" --author \"$3\" --output \"$4\""
 
 proc run*(command: string, args: varargs[string, `$`]): bool =
     let commandString = command.format(args).replace("\\", "/")


### PR DESCRIPTION
some filenames can be valid but require quotations to be properly handled
this should, for example, fix apostrophes throwing "Syntax error: Unterminated quoted string"

admittedly untested